### PR TITLE
Add tsx/jsx fallback in swap_to_from_scss

### DIFF
--- a/fish/functions/swap_to_from_scss.fish
+++ b/fish/functions/swap_to_from_scss.fish
@@ -1,6 +1,15 @@
 function swap_to_from_scss
     if string match -q -r '\\.scss$' "$ZED_FILE"
-        set -f target_file (string replace -r '\\.scss$' '.res' "$ZED_FILE")
+        set -f base (string replace -r '\\.scss$' '' "$ZED_FILE")
+        if test -f "$base.res"
+            set -f target_file "$base.res"
+        else if test -f "$base.tsx"
+            set -f target_file "$base.tsx"
+        else if test -f "$base.jsx"
+            set -f target_file "$base.jsx"
+        else
+            set -f target_file "$base.res"
+        end
     else
         set -f target_file (string replace -r '\\.\\w+$' '.scss' "$ZED_FILE")
     end

--- a/fish/tests/test_swap_to_from_scss.fish
+++ b/fish/tests/test_swap_to_from_scss.fish
@@ -31,4 +31,13 @@ end
     swap_to_from_scss
 ) = "$res_file:2"
 
+@test "fallback to .tsx if .res missing" (
+    set -gx ZED_FILE $scss_file
+    set -e ZED_SELECTED_TEXT
+    rm $res_file
+    set -g tsx_file "$tmpdir/foo.tsx"
+    touch $tsx_file
+    swap_to_from_scss
+) = $tsx_file
+
 rm -rf $tmpdir


### PR DESCRIPTION
## Summary
- support `.tsx`/`.jsx` fallback when swapping from `.scss`
- add test for new fallback behaviour

## Testing
- `fish -c 'fishtape fish/tests/*.fish'`

------
https://chatgpt.com/codex/tasks/task_e_6882a7a86e44832088dc7e0ec936ac98