### PR TITLE
Support .bs.js to .res swap in Zed alt-g binding

### DIFF
--- a/fish/functions/swap_to_from_scss.fish
+++ b/fish/functions/swap_to_from_scss.fish
@@ -10,6 +10,8 @@ function swap_to_from_scss
         else
             set -f target_file "$base.res"
         end
+    else if string match -q -r '\\.bs\\.js$' "$ZED_FILE"
+        set -f target_file (string replace -r '\\.bs\\.js$' '.res' "$ZED_FILE")
     else
         set -f target_file (string replace -r '\\.\\w+$' '.scss' "$ZED_FILE")
     end

--- a/fish/tests/test_swap_to_from_scss.fish
+++ b/fish/tests/test_swap_to_from_scss.fish
@@ -5,9 +5,11 @@
 set -g tmpdir (mktemp -d)
 set -g scss_file "$tmpdir/foo.scss"
 set -g res_file "$tmpdir/foo.res"
+set -g bsjs_file "$tmpdir/foo.bs.js"
 
 echo "color: red;" > $scss_file
 printf "hello\nworld\n" > $res_file
+touch $bsjs_file
 
 function zed
     echo $argv
@@ -30,6 +32,12 @@ end
     set -gx ZED_SELECTED_TEXT "world"
     swap_to_from_scss
 ) = "$res_file:2"
+
+@test "open .res from .bs.js" (
+    set -gx ZED_FILE $bsjs_file
+    set -e ZED_SELECTED_TEXT
+    swap_to_from_scss
+) = $res_file
 
 @test "fallback to .tsx if .res missing" (
     set -gx ZED_FILE $scss_file


### PR DESCRIPTION
## Summary
- Open corresponding `.res` file when Alt-G is pressed on a `.bs.js` file
- Test swap function for `.bs.js` files

## Testing
- `./codex/test.fish >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68bec5d4d52c8320aee477be51545b79