### PR TITLE
Add flash message command and display on interactive Fish startup

### DIFF
--- a/fish/.gitignore
+++ b/fish/.gitignore
@@ -32,6 +32,8 @@
 !functions/_jj_squash_abbr.fish
 !functions/_jj_describe_abbr_no_msg.fish
 !functions/wt.fish
+!functions/flash_message.fish
+!functions/flash_message_show.fish
 
 # Tests
 !tests

--- a/fish/config.fish
+++ b/fish/config.fish
@@ -39,6 +39,12 @@ if status is-interactive
 
     # Prompt
     set -g lucid_prompt_symbol_error "!"
+
+    set -l _flash_messages (flash_message_show | string collect)
+    if test -n "$_flash_messages"
+        echo "Flash messages:"
+        echo $_flash_messages
+    end
 end
 
 # Be verbose

--- a/fish/functions/flash_message.fish
+++ b/fish/functions/flash_message.fish
@@ -1,0 +1,25 @@
+function flash_message --description 'Save or clear fish flash messages'
+    set -l flash_messages_dir ~/.config/fish/flash_messages
+    if set -q FLASH_MESSAGES_DIR
+        set flash_messages_dir $FLASH_MESSAGES_DIR
+    end
+
+    if test "$argv[1]" = "--clear" -o "$argv[1]" = "—clear"
+        mkdir -p $flash_messages_dir
+        for file in $flash_messages_dir/*
+            if test -f $file
+                rm -f $file
+            end
+        end
+        return 0
+    end
+
+    if test (count $argv) -eq 0
+        echo "Usage: flash_message <message> | --clear" >&2
+        return 1
+    end
+
+    mkdir -p $flash_messages_dir
+    set -l file_name (date '+%Y%m%d%H%M%S')"_"(random)".txt"
+    string join ' ' -- $argv >$flash_messages_dir/$file_name
+end

--- a/fish/functions/flash_message_show.fish
+++ b/fish/functions/flash_message_show.fish
@@ -1,0 +1,14 @@
+function flash_message_show --description 'Show all saved fish flash messages'
+    set -l flash_messages_dir ~/.config/fish/flash_messages
+    if set -q FLASH_MESSAGES_DIR
+        set flash_messages_dir $FLASH_MESSAGES_DIR
+    end
+
+    if not test -d $flash_messages_dir
+        return 0
+    end
+
+    for file in (find $flash_messages_dir -type f | sort)
+        cat $file
+    end
+end

--- a/fish/tests/test_flash_message.fish
+++ b/fish/tests/test_flash_message.fish
@@ -1,0 +1,26 @@
+#!/usr/bin/env fish
+
+@echo "Testing flash_message function"
+
+set -l tmpdir (mktemp -d)
+set -lx FLASH_MESSAGES_DIR $tmpdir
+
+@test "flash_message without args shows usage" (flash_message 2>&1) = "Usage: flash_message <message> | --clear"
+
+flash_message "Remember to send standup"
+set -l files (find $tmpdir -type f | wc -l | string trim)
+@test "flash_message creates a file" $files = "1"
+
+set -l shown (flash_message_show)
+@test "flash_message_show prints saved messages" "$shown" = "Remember to send standup"
+
+flash_message --clear
+set -l remaining (find $tmpdir -type f | wc -l | string trim)
+@test "flash_message --clear removes all files" $remaining = "0"
+
+flash_message "Another reminder"
+flash_message —clear
+set -l remaining_after_em_dash (find $tmpdir -type f | wc -l | string trim)
+@test "flash_message —clear also removes all files" $remaining_after_em_dash = "0"
+
+rm -rf $tmpdir


### PR DESCRIPTION
### Motivation
- Provide a simple CLI to save short reminders at the end of the day and have them displayed automatically the next interactive Fish session.
- Allow clearing stored reminders via a single command so messages don't persist after being acknowledged.

### Description
- Add `flash_message` which saves a message file under `~/.config/fish/flash_messages/`, accepts a custom `FLASH_MESSAGES_DIR`, and supports both `--clear` and the Unicode em-dash `—clear` to remove stored messages.
- Add `flash_message_show` which reads and prints messages from the flash messages directory in sorted order.
- Wire `flash_message_show` into interactive startup in `fish/config.fish` so messages are printed when a new interactive shell opens (uses `string collect` to capture multi-line output).
- Add a `fishtape` test `fish/tests/test_flash_message.fish` exercising usage, save, show, and both clear variants, and whitelist the two new function files in `fish/.gitignore`.

### Testing
- Ran `fish -c 'fishtape fish/tests/test_flash_message.fish'` and the new flash message tests passed (all tests ok).
- Ran the repo-wide test script `./codex/test.fish`, which shows the new flash tests passing while one unrelated existing test fails because the `jj` tool is not available in this environment; failure is not related to the flash message changes.
- Verified interactive startup hook by inspecting `fish/config.fish` to ensure `flash_message_show` is called only in interactive sessions and that output is printed when messages exist.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a01bd3d2808320b7c97ed41fcf287d)